### PR TITLE
Fix Dockerfile for cross building with dotnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 ARG TARGETPLATFORM
+ARG TARGETARCH
 ARG BUILDPLATFORM
 WORKDIR /app
 EXPOSE 7095
@@ -10,17 +11,18 @@ RUN apt-get update -yq && apt-get upgrade -yq && apt-get install -yq ffmpeg
 
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG TARGETPLATFORM
+ARG TARGETARCH
 ARG BUILDPLATFORM
 WORKDIR /src
 COPY ["StreamMasterAPI/StreamMasterAPI.csproj", "StreamMasterAPI/"]
 COPY ["StreamMasterApplication/StreamMasterApplication.csproj", "StreamMasterApplication/"]
 COPY ["StreamMasterDomain/StreamMasterDomain.csproj", "StreamMasterDomain/"]
 COPY ["StreamMasterInfrastructure/StreamMasterInfrastructure.csproj", "StreamMasterInfrastructure/"]
-RUN dotnet restore "StreamMasterAPI/StreamMasterAPI.csproj"
+RUN dotnet restore "StreamMasterAPI/StreamMasterAPI.csproj" -a $TARGETARCH
 COPY . .
 WORKDIR "/src/StreamMasterAPI"
 #RUN if [ "$ENV" = "debug" ] ; then dotnet build "StreamMasterAPI.csproj" -c Debug -o /app/build; else dotnet build "StreamMasterAPI.csproj" -c Release -o /app/build; fi
-RUN dotnet build "StreamMasterAPI.csproj" -c Debug -o /app/build
+RUN dotnet build "StreamMasterAPI.csproj" -c Debug -o /app/build -a $TARGETARCH
 # installs NodeJS and NPM
 RUN apt-get update -yq && apt-get upgrade -yq && apt-get install -yq curl git nano
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -yq nodejs build-essential
@@ -32,16 +34,21 @@ RUN npm run build
 RUN cp -r build/* /src/StreamMasterAPI/wwwroot/
 WORKDIR "/src/StreamMasterAPI"
 
-FROM --platform=$BUILDPLATFORM build AS publish
+FROM build AS publish
 # RUN if [ "$ENV" = "debug" ] ; then dotnet publish "StreamMasterAPI.csproj" -c Debug -o /app/publish /p:UseAppHost=false; else dotnet publish "StreamMasterAPI.csproj" -c Release -o /app/publish /p:UseAppHost=false ; fi
 ARG TARGETPLATFORM
+ARG TARGETARCH
 ARG BUILDPLATFORM
-RUN dotnet publish "StreamMasterAPI.csproj" -c Debug -o /app/publish /p:UseAppHost=false;
+RUN dotnet publish --no-restore "StreamMasterAPI.csproj" -c Debug -o /app/publish /p:UseAppHost=false -a $TARGETARCH
 
-FROM --platform=$BUILDPLATFORM base AS final
+
+FROM  base AS final
+#FROM base AS final
 ARG TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+ARG TARGETARCH
 ARG BUILDPLATFORM
-LABEL       org.opencontainers.image.url="https://hub.docker.com/r/SenexCrenshaw/streammaster/" \
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/SenexCrenshaw/streammaster/" \
       org.opencontainers.image.source="https://github.com/SenexCrenshaw/StreamMaster" \      
       org.opencontainers.image.vendor="SenexCrenshaw" \
       org.opencontainers.image.title="Stream Master" \


### PR DESCRIPTION
## Description

Crossbuilding for different Architectures was not working correctly, resulting in unusable images for `arm` and `arm64` 

This should fix the issue. For reference see https://github.com/dotnet/dotnet-docker/issues/4388 and https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
