### PR TITLE
Detect X-Forwarded-For header when reverse proxy is used

### DIFF
--- a/StreamMaster.API/Controllers/VideoStreamsController.cs
+++ b/StreamMaster.API/Controllers/VideoStreamsController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-
 using StreamMaster.Application.StreamGroups.Commands;
 using StreamMaster.Application.VideoStreams;
 using StreamMaster.Application.VideoStreams.Commands;
@@ -144,8 +143,15 @@ public class VideoStreamsController : ApiControllerBase, IVideoStreamController
             return Redirect(videoStream.User_Url);
         }
 
-
-        string? ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+        string? ipAddress;
+        if (HttpContext.Request.Headers.ContainsKey("X-Forwarded-For"))
+        {
+            ipAddress = HttpContext.Request.Headers["X-Forwarded-For"].ToString();
+        }
+        else
+        {
+            ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+        }
 
         ClientStreamerConfiguration config = new(videoStream.Id, videoStream.User_Tvg_name, Request.Headers["User-Agent"].ToString(), ipAddress ?? "unkown", cancellationToken, HttpContext.Response);
 


### PR DESCRIPTION
## Description

I added an if-case in VideoStreamsController that checks for the X-Forwarded-For header so that when a reverse proxy is used, the client host panel will show the proxied IP instead. There could be some setting in the future for a trusted downstream proxy, but I'll just conveniently assume that a client which can already access the server is unlikely an attacker. 

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
