### PR TITLE
FIX use correct binary architecture for ffmpeg/ffprobe on arm64

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,7 +18,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /docker-entrypoint-initdb.d
 
-RUN if [ "$TARGETARCH" = "arm64" ]; then curl -L -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz; else curl -L -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz; fi
+RUN if [ "$TARGETARCH" = "arm64" ]; then curl -L -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz; else curl -L -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz; fi
 
 RUN mkdir /tmp/ffmpeg/ \
     && tar -Jxvvf /tmp/ffmpeg.tar.xz --strip-components=1 -C /tmp/ffmpeg/ \


### PR DESCRIPTION
## Description

Wrong binaries are used for arm64 in Dockerfile. base

https://github.com/SenexCrenshaw/StreamMaster/blob/5a2704bd52d6449ba418c50a8e5e5711ba2cc1d3/Dockerfile.base#L21

This PR changes the curl command to download the correct ffpmeg archive for arm64.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
